### PR TITLE
Llm-463 - Fixed unit tests adding mocks to avoid making actual requests ✨

### DIFF
--- a/modules/embeddingsgeneration/build.gradle
+++ b/modules/embeddingsgeneration/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-core:5.5.0'
 }
 
 test {

--- a/modules/embeddingsgeneration/build.gradle
+++ b/modules/embeddingsgeneration/build.gradle
@@ -16,7 +16,8 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
-    testImplementation 'org.mockito:mockito-core:5.5.0'
+    testImplementation 'org.mockito:mockito-core:3.+'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.5.0'
 }
 
 test {

--- a/modules/embeddingsgeneration/src/main/java/com/theagilemonkeys/ellmental/embeddingsgeneration/openai/OpenAIEmbeddingsModel.java
+++ b/modules/embeddingsgeneration/src/main/java/com/theagilemonkeys/ellmental/embeddingsgeneration/openai/OpenAIEmbeddingsModel.java
@@ -16,9 +16,12 @@ import java.util.UUID;
  * OpenAI `EmbeddingsGenerationModel` implementation.
  */
 public class OpenAIEmbeddingsModel extends EmbeddingsGenerationModel {
-    private static String openAIKey;
-    private static OpenAiService cachedService;
+    private final String openAIKey;
     public static String embeddingOpenAiModel = "text-embedding-ada-002";
+
+    // This attribute needs no modifier to allow injection from tests,
+    // It is accessible for other classes in this package, but won't be accessible to end users.
+    OpenAiService openAiService;
 
     /**
      * Constructor that initializes the OpenAI embeddings model with an explicit API Key.
@@ -60,18 +63,13 @@ public class OpenAIEmbeddingsModel extends EmbeddingsGenerationModel {
         return new Embedding(UUID.randomUUID(), vector, metadata);
     }
 
-    // We initialize the service with the API key in a protected method, so we can mock it in tests
-    protected OpenAiService createOpenAiService(String apiKey) {
-        return new OpenAiService(apiKey);
-    }
-
     private OpenAiService getService() {
-        if (cachedService == null) {
+        if (openAiService == null) {
             if (openAIKey == null) {
                 throw new MissingRequiredCredentialException("OpenAI API key is required.");
             }
-            cachedService = createOpenAiService(openAIKey);
+            openAiService = new OpenAiService(openAIKey);
         }
-        return cachedService;
+        return openAiService;
     }
 }

--- a/modules/embeddingsgeneration/src/main/java/com/theagilemonkeys/ellmental/embeddingsgeneration/openai/OpenAIEmbeddingsModel.java
+++ b/modules/embeddingsgeneration/src/main/java/com/theagilemonkeys/ellmental/embeddingsgeneration/openai/OpenAIEmbeddingsModel.java
@@ -60,12 +60,17 @@ public class OpenAIEmbeddingsModel extends EmbeddingsGenerationModel {
         return new Embedding(UUID.randomUUID(), vector, metadata);
     }
 
+    // We initialize the service with the API key in a protected method, so we can mock it in tests
+    protected OpenAiService createOpenAiService(String apiKey) {
+        return new OpenAiService(apiKey);
+    }
+
     private OpenAiService getService() {
         if (cachedService == null) {
             if (openAIKey == null) {
                 throw new MissingRequiredCredentialException("OpenAI API key is required.");
             }
-            cachedService = new OpenAiService(openAIKey);
+            cachedService = createOpenAiService(openAIKey);
         }
         return cachedService;
     }

--- a/modules/embeddingsgeneration/src/test/java/com/theagilemonkeys/ellmental/embeddingsgeneration/openai/OpenAIEmbeddingsModelTest.java
+++ b/modules/embeddingsgeneration/src/test/java/com/theagilemonkeys/ellmental/embeddingsgeneration/openai/OpenAIEmbeddingsModelTest.java
@@ -1,40 +1,42 @@
 package com.theagilemonkeys.ellmental.embeddingsgeneration.openai;
 
-
 import com.theagilemonkeys.ellmental.core.schema.Embedding;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
+import static org.mockito.Mockito.*;
 import com.theokanning.openai.embedding.EmbeddingResult;
 import com.theokanning.openai.service.OpenAiService;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.UUID;
-
-
 import java.util.List;
 
+@ExtendWith(MockitoExtension.class)
 public class OpenAIEmbeddingsModelTest {
-   @Test
-    public void testGenerateEmbedding(){
-        OpenAIEmbeddingsModel openAI = new OpenAIEmbeddingsModel("fakeAPIKey") {
-            @Override
-            protected OpenAiService createOpenAiService(String apiKey) {
-                OpenAiService mockService = mock(OpenAiService.class);
+    @Mock
+    private OpenAiService openAiService;
 
-                com.theokanning.openai.embedding.Embedding vector = new com.theokanning.openai.embedding.Embedding();
-                TestValues testValues = new TestValues();
-                vector.setEmbedding(testValues.testGenerateEmbeddingExpectedValue);
-                EmbeddingResult result = new EmbeddingResult();
-                result.setData(List.of(vector));
+    private OpenAIEmbeddingsModel openAIEmbeddingsModel;
 
-                when(mockService.createEmbeddings(any())).thenReturn(result);
-                return mockService;
-            }
-        };
-        Embedding embedding = openAI.generateEmbedding("The Agile Monkeys rule!");
+    @BeforeEach
+    public void setUp() {
+        openAIEmbeddingsModel = new OpenAIEmbeddingsModel("fakeAPIKey");
+        openAIEmbeddingsModel.openAiService = openAiService;
+    }
+
+    @Test
+    public void testGenerateEmbedding() {
+        com.theokanning.openai.embedding.Embedding vector = new com.theokanning.openai.embedding.Embedding();
         TestValues testValues = new TestValues();
+        vector.setEmbedding(testValues.testGenerateEmbeddingExpectedValue);
+        EmbeddingResult result = new EmbeddingResult();
+        result.setData(List.of(vector));
+
+        when(openAiService.createEmbeddings(any())).thenReturn(result);
+
+        Embedding embedding = openAIEmbeddingsModel.generateEmbedding("The Agile Monkeys rule!");
 
         // The id is not null and is a valid UUID
         assertNotNull(embedding.id());
@@ -60,7 +62,6 @@ public class OpenAIEmbeddingsModelTest {
         assertDoesNotThrow(() -> java.time.LocalDateTime.parse(createdAt));
     }
 }
-
 
 class TestValues {
     List<Double> testGenerateEmbeddingExpectedValue = List.of(

--- a/modules/embeddingsspace/src/test/java/com/theagilemonkeys/ellmental/embeddingsspace/EmbeddingsSpaceComponentTest.java
+++ b/modules/embeddingsspace/src/test/java/com/theagilemonkeys/ellmental/embeddingsspace/EmbeddingsSpaceComponentTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class EmbeddingsSpaceComponentTest {
-
     @Mock
     private EmbeddingsGenerationModel embeddingsGenerationModel;
     @Mock


### PR DESCRIPTION
> **Warning: #20 should be merged first!**

* Mocked the `OpenAiService` object to test the `generateEmbedding` method in the `OpenAIEmbeddingsModel` class.
* Improved the test to check for the new `Embedding` structure and expected metadata.
* Mocked `OkHttpClient` to implement positive and negative requests to the Pinecone API.
* Completed tests for `store` and `similaritySearch` methods in the class `PineconeEmbeddingsStore`.

I've also checked that all tests are run with the command `./gradlew test`, so we should be able to easily run the test suite in a github action.