### PR TITLE
Automate publishing the library to maven central

### DIFF
--- a/.github/workflows/wf_publish-to-maven-central.yml
+++ b/.github/workflows/wf_publish-to-maven-central.yml
@@ -1,0 +1,28 @@
+name: Publish package to the Maven Central Repository
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@01ad6d2663fa6fc4add68e686ff72c415a2cf3c3
+      - name: Publish package
+        uses: gradle/gradle-build-action@3bfe3a46584a206fb8361cdedd0647b0c4204232
+        with:
+          arguments: publish -Pversion=${{ github.event.release.tag_name }}
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          MAVEN_BASE64_PRIVATE_KEY: ${{ secrets.MAVEN_BASE64_PRIVATE_KEY }}
+          MAVEN_KEY_PASSPHRASE: ${{ secrets.MAVEN_KEY_PASSPHRASE }}

--- a/.github/workflows/wf_publish-to-maven-central.yml
+++ b/.github/workflows/wf_publish-to-maven-central.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@01ad6d2663fa6fc4add68e686ff72c415a2cf3c3

--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,8 @@ subprojects { subproject ->
                     url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
 
                     credentials {
-                        username project.findProperty("ossrhUsername") ?: ""
-                        password project.findProperty("ossrhPassword") ?: ""
+                        username = System.getenv("MAVEN_USERNAME")
+                        password = System.getenv("MAVEN_PASSWORD")
                     }
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,22 @@
 plugins {
-    id("java")
+    id "java"
+    id "io.freefair.lombok" version "8.3"
+    id 'maven-publish'
+    id 'signing'
 }
 
 def rootGroup = "com.theagilemonkeys.ellmental"
-def rootVersion = "1.0-SNAPSHOT"
+def rootVersion = properties['version']
+def rootSourceCompatibility = properties['sourceCompatibility']
 
-repositories {
-    mavenCentral()
+allprojects {
+    repositories {
+        mavenCentral()
+    }
 }
 
 java {
-    sourceCompatibility = '17'
+    sourceCompatibility = rootSourceCompatibility
 }
 
 dependencies {
@@ -18,15 +24,16 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
-subprojects {
+subprojects { subproject ->
     group = rootGroup
     version = rootVersion
 
-
     apply plugin: 'java'
+    apply plugin: 'io.freefair.lombok'
     apply plugin: 'maven-publish'
+    apply plugin: 'signing'
 
-    sourceCompatibility = '17'
+    sourceCompatibility = rootSourceCompatibility
 
     java {
         withSourcesJar()
@@ -37,17 +44,51 @@ subprojects {
         mavenCentral()
     }
 
-    dependencies{
-
+    test {
+        useJUnitPlatform()
     }
 
-    publishing {
-        publications {
-            maven(MavenPublication) {
-                groupId project.group
-                artifactId project.name
-                version project.version
-                from components.java
+    if (!subproject.name.startsWith('examples:')) {
+        publishing {
+            publications {
+                mavenJava(MavenPublication) {
+                    from components.java
+
+                    groupId = subproject.group
+                    artifactId = subproject.name
+                    version = subproject.version
+
+                    // Additional Pom information
+                    pom {
+                        name = subproject.name
+                        description = subproject.description
+                        // ... other POM properties
+                    }
+                }
+            }
+
+            repositories {
+                maven {
+                    name = 'OSSRH'
+                    url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+
+                    credentials {
+                        username project.findProperty("ossrhUsername") ?: ""
+                        password project.findProperty("ossrhPassword") ?: ""
+                    }
+                }
+            }
+        }
+
+        signing {
+            def privateKey = System.getenv('MAVEN_BASE64_PRIVATE_KEY')
+            def passphrase = System.getenv('MAVEN_KEY_PASSPHRASE')
+
+            if (privateKey && passphrase) {
+                useInMemoryPgpKeys(privateKey, passphrase)
+                sign publishing.publications
+            } else {
+                println "Private key or passphrase for signing not found. Skipping signing..."
             }
         }
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'java'
+    id 'maven-publish'
+    id 'signing'
     id "io.freefair.lombok" version "8.3"
 }
 
@@ -15,4 +17,40 @@ repositories {
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+
+            groupId = 'com.theagilemonkeys.ellmental'
+            artifactId = project.name
+            version = '0.0.1'
+
+            // Additional Pom information
+            pom {
+                name = project.name
+                description = 'Core package of ELLMENTAL, the ultimate AI toolkit for Java'
+                // ... other POM properties
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = 'OSSRH'
+            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+
+            credentials {
+                username project.findProperty("ossrhUsername") ?: ""
+                password project.findProperty("ossrhPassword") ?: ""
+            }
+        }
+    }
+}
+
+
+signing {
+    sign publishing.publications
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,56 +1,7 @@
-plugins {
-    id 'java'
-    id 'maven-publish'
-    id 'signing'
-    id "io.freefair.lombok" version "8.3"
-}
-
-
-group = "com.theagilemonkeys.ellmental"
-version = '1.0-SNAPSHOT'
-
-
-repositories {
-    mavenCentral()
-}
+// All the common configuration is set in the root build.gradle file
+description = 'Core package of ELLMENTAL, the ultimate AI toolkit for Java'
 
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-
-            groupId = 'com.theagilemonkeys.ellmental'
-            artifactId = project.name
-            version = '0.0.1'
-
-            // Additional Pom information
-            pom {
-                name = project.name
-                description = 'Core package of ELLMENTAL, the ultimate AI toolkit for Java'
-                // ... other POM properties
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            name = 'OSSRH'
-            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-
-            credentials {
-                username project.findProperty("ossrhUsername") ?: ""
-                password project.findProperty("ossrhPassword") ?: ""
-            }
-        }
-    }
-}
-
-
-signing {
-    sign publishing.publications
 }

--- a/examples/simplejava/build.gradle
+++ b/examples/simplejava/build.gradle
@@ -1,13 +1,5 @@
 plugins {
-    id 'java'
     id 'application'
-}
-
-group = 'com.theagilemonkeys.ellmental'
-version = '1.0-SNAPSHOT'
-
-repositories {
-    mavenCentral()
 }
 
 application {

--- a/examples/webcrawler/build.gradle
+++ b/examples/webcrawler/build.gradle
@@ -1,18 +1,6 @@
 plugins {
-	id 'java'
 	id 'org.springframework.boot' version '3.1.3'
 	id 'io.spring.dependency-management' version '1.1.3'
-}
-
-group = 'com.theagilemonkeys'
-version = '0.0.1-SNAPSHOT'
-
-java {
-	sourceCompatibility = '17'
-}
-
-repositories {
-	mavenCentral()
 }
 
 dependencies {
@@ -29,8 +17,4 @@ dependencies {
 
 	// Load test dependencies
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-}
-
-tasks.named('test') {
-	useJUnitPlatform()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+version = 0.0.1
+sourceCompatibility = 17

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
-version = 0.0.1
 sourceCompatibility = 17

--- a/modules/embeddingsgeneration/build.gradle
+++ b/modules/embeddingsgeneration/build.gradle
@@ -1,17 +1,5 @@
-plugins {
-    id 'java'
-    id "io.freefair.lombok" version "8.3"
-    id 'maven-publish'
-    id 'signing'
-}
-
-group = "com.theagilemonkeys.ellmental"
-version = '1.0-SNAPSHOT'
-
-
-repositories {
-    mavenCentral()
-}
+// All the common configuration is set in the root build.gradle file
+description = 'Embeddings generation component of ELLMENTAL, the ultimate AI toolkit for Java'
 
 dependencies {
     implementation 'ch.qos.logback:logback-core:1.4.11'
@@ -24,44 +12,4 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.mockito:mockito-core:3.+'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.5.0'
-}
-
-test {
-    useJUnitPlatform()
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-
-            groupId = 'com.theagilemonkeys.ellmental'
-            artifactId = project.name
-            version = '0.0.1'
-
-            // Additional Pom information
-            pom {
-                name = project.name
-                description = 'Core package of ELLMENTAL, the ultimate AI toolkit for Java'
-                // ... other POM properties
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            name = 'OSSRH'
-            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-
-            credentials {
-                username project.findProperty("ossrhUsername") ?: ""
-                password project.findProperty("ossrhPassword") ?: ""
-            }
-        }
-    }
-}
-
-
-signing {
-    sign publishing.publications
 }

--- a/modules/embeddingsgeneration/build.gradle
+++ b/modules/embeddingsgeneration/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'java'
     id "io.freefair.lombok" version "8.3"
+    id 'maven-publish'
+    id 'signing'
 }
 
 group = "com.theagilemonkeys.ellmental"
@@ -26,4 +28,40 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+
+            groupId = 'com.theagilemonkeys.ellmental'
+            artifactId = project.name
+            version = '0.0.1'
+
+            // Additional Pom information
+            pom {
+                name = project.name
+                description = 'Core package of ELLMENTAL, the ultimate AI toolkit for Java'
+                // ... other POM properties
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = 'OSSRH'
+            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+
+            credentials {
+                username project.findProperty("ossrhUsername") ?: ""
+                password project.findProperty("ossrhPassword") ?: ""
+            }
+        }
+    }
+}
+
+
+signing {
+    sign publishing.publications
 }

--- a/modules/embeddingsspace/build.gradle
+++ b/modules/embeddingsspace/build.gradle
@@ -1,17 +1,5 @@
-plugins {
-    id 'java'
-    id "io.freefair.lombok" version "8.3"
-    id 'maven-publish'
-    id 'signing'
-}
-
-group = "com.theagilemonkeys.ellmental"
-version = '1.0-SNAPSHOT'
-
-
-repositories {
-    mavenCentral()
-}
+// All the common configuration is set in the root build.gradle file
+description = 'Embeddings space component of ELLMENTAL, the ultimate AI toolkit for Java'
 
 dependencies {
     implementation 'ch.qos.logback:logback-core:1.4.11'
@@ -25,44 +13,4 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.mockito:mockito-core:3.+'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.5.0'
-}
-
-test {
-    useJUnitPlatform()
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-
-            groupId = 'com.theagilemonkeys.ellmental'
-            artifactId = project.name
-            version = '0.0.1'
-
-            // Additional Pom information
-            pom {
-                name = project.name
-                description = 'Core package of ELLMENTAL, the ultimate AI toolkit for Java'
-                // ... other POM properties
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            name = 'OSSRH'
-            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-
-            credentials {
-                username project.findProperty("ossrhUsername") ?: ""
-                password project.findProperty("ossrhPassword") ?: ""
-            }
-        }
-    }
-}
-
-
-signing {
-    sign publishing.publications
 }

--- a/modules/embeddingsspace/build.gradle
+++ b/modules/embeddingsspace/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'java'
     id "io.freefair.lombok" version "8.3"
+    id 'maven-publish'
+    id 'signing'
 }
 
 group = "com.theagilemonkeys.ellmental"
@@ -27,4 +29,40 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+
+            groupId = 'com.theagilemonkeys.ellmental'
+            artifactId = project.name
+            version = '0.0.1'
+
+            // Additional Pom information
+            pom {
+                name = project.name
+                description = 'Core package of ELLMENTAL, the ultimate AI toolkit for Java'
+                // ... other POM properties
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = 'OSSRH'
+            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+
+            credentials {
+                username project.findProperty("ossrhUsername") ?: ""
+                password project.findProperty("ossrhPassword") ?: ""
+            }
+        }
+    }
+}
+
+
+signing {
+    sign publishing.publications
 }

--- a/modules/embeddingsstore/build.gradle
+++ b/modules/embeddingsstore/build.gradle
@@ -1,16 +1,5 @@
-plugins {
-    id 'java'
-    id "io.freefair.lombok" version "8.3"
-    id 'maven-publish'
-    id 'signing'
-}
-
-group = 'com.theagilemonkeys.ellemental'
-version = '1.0-SNAPSHOT'
-
-repositories {
-    mavenCentral()
-}
+// All the common configuration is set in the root build.gradle file
+description = 'Embeddings store component of ELLMENTAL, the ultimate AI toolkit for Java'
 
 dependencies {
     implementation 'ch.qos.logback:logback-core:1.4.11'
@@ -24,44 +13,4 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.mockito:mockito-core:3.+'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.5.0'
-}
-
-test {
-    useJUnitPlatform()
-}
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-
-            groupId = 'com.theagilemonkeys.ellmental'
-            artifactId = project.name
-            version = '0.0.1'
-
-            // Additional Pom information
-            pom {
-                name = project.name
-                description = 'Core package of ELLMENTAL, the ultimate AI toolkit for Java'
-                // ... other POM properties
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            name = 'OSSRH'
-            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-
-            credentials {
-                username project.findProperty("ossrhUsername") ?: ""
-                password project.findProperty("ossrhPassword") ?: ""
-            }
-        }
-    }
-}
-
-
-signing {
-    sign publishing.publications
 }

--- a/modules/embeddingsstore/build.gradle
+++ b/modules/embeddingsstore/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'java'
     id "io.freefair.lombok" version "8.3"
+    id 'maven-publish'
+    id 'signing'
 }
 
 group = 'com.theagilemonkeys.ellemental'
@@ -26,4 +28,40 @@ dependencies {
 
 test {
     useJUnitPlatform()
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+
+            groupId = 'com.theagilemonkeys.ellmental'
+            artifactId = project.name
+            version = '0.0.1'
+
+            // Additional Pom information
+            pom {
+                name = project.name
+                description = 'Core package of ELLMENTAL, the ultimate AI toolkit for Java'
+                // ... other POM properties
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = 'OSSRH'
+            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+
+            credentials {
+                username project.findProperty("ossrhUsername") ?: ""
+                password project.findProperty("ossrhPassword") ?: ""
+            }
+        }
+    }
+}
+
+
+signing {
+    sign publishing.publications
 }

--- a/modules/textgeneration/build.gradle
+++ b/modules/textgeneration/build.gradle
@@ -1,14 +1,5 @@
-plugins {
-    id 'java'
-    id "io.freefair.lombok" version "8.3"
-}
-
-group = 'com.theagilemonkeys.ellemental'
-version = '1.0-SNAPSHOT'
-
-repositories {
-    mavenCentral()
-}
+// All the common configuration is set in the root build.gradle file
+description = 'Text generation module of ELLMENTAL, the ultimate AI toolkit for Java'
 
 dependencies {
     implementation 'ch.qos.logback:logback-core:1.4.11'


### PR DESCRIPTION
* Added the `maven-publish` and `signing` plugins to each package's `gradle. build` files.
* Refactored the gradle scripts to avoid code duplication
* Created a Github Action script that uploads the library to Maven Central after creating a Github release, using the release tag as the version

To try the action and check that the upload script works, we would first need to merge this PR